### PR TITLE
Add support to new version of qmod schema

### DIFF
--- a/QuestPatcher.Core/Modding/IMod.cs
+++ b/QuestPatcher.Core/Modding/IMod.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -60,6 +61,11 @@ namespace QuestPatcher.Core.Modding
         /// Whether or not the mod is a library
         /// </summary>
         bool IsLibrary { get; }
+        
+        /// <summary>
+        /// The file types that this mod supports.
+        /// </summary>
+        IEnumerable<FileCopyType> FileCopyTypes { get; }
 
         /// <summary>
         /// Installs the mod

--- a/QuestPatcher.Core/Modding/IMod.cs
+++ b/QuestPatcher.Core/Modding/IMod.cs
@@ -34,7 +34,7 @@ namespace QuestPatcher.Core.Modding
         /// <summary>
         /// Version of the package that the mod is intended for
         /// </summary>
-        string PackageVersion { get; }
+        string? PackageVersion { get; }
         
         /// <summary>
         /// Author of the mod

--- a/QuestPatcher.Core/Modding/QModProvider.cs
+++ b/QuestPatcher.Core/Modding/QModProvider.cs
@@ -52,7 +52,7 @@ namespace QuestPatcher.Core.Modding
             
             // Check that the package ID is correct. We don't want people installing Beat Saber mods on Gorilla Tag!
             _logger.Information($"Mod ID: {qmod.Id}, Version: {qmod.Version}, Is Library: {qmod.IsLibrary}");
-            if (qmod.PackageId != _config.AppId)
+            if (qmod.PackageId != null && qmod.PackageId != _config.AppId)
             {
                 throw new InstallationException($"该Mod适用于{qmod.PackageId}，与你目前要Mod的应用{_config.AppId}不兼容。");
             }

--- a/QuestPatcher.Core/Modding/QPMod.cs
+++ b/QuestPatcher.Core/Modding/QPMod.cs
@@ -21,7 +21,7 @@ namespace QuestPatcher.Core.Modding
         public string Name => Manifest.Name;
         public string? Description => Manifest.Description;
         public SemanticVersioning.Version Version => Manifest.Version;
-        public string PackageVersion => Manifest.PackageVersion;
+        public string? PackageVersion => Manifest.PackageVersion;
         public string Author => Manifest.Author;
         public string? Porter => Manifest.Porter;
         public bool IsLibrary => false;

--- a/QuestPatcher.Core/Modding/QPMod.cs
+++ b/QuestPatcher.Core/Modding/QPMod.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -25,6 +26,8 @@ namespace QuestPatcher.Core.Modding
         public string Author => Manifest.Author;
         public string? Porter => Manifest.Porter;
         public bool IsLibrary => false;
+
+        public IEnumerable<FileCopyType> FileCopyTypes { get; }
 
         public bool IsInstalled
         {
@@ -57,6 +60,14 @@ namespace QuestPatcher.Core.Modding
             _logger = logger;
             _filesDownloader = filesDownloader;
             _modManager = modManager;
+
+            FileCopyTypes = manifest.CopyExtensions.Select(copyExt => new FileCopyType(debugBridge)
+            {
+                NameSingular = $"{manifest.Name} .{copyExt.Extension} file",
+                NamePlural = $"{manifest.Name} .{copyExt.Extension} files",
+                Path = copyExt.Destination,
+                SupportedExtensions = new List<string> { copyExt.Destination }
+            }).ToList();
         }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")

--- a/QuestPatcher.Core/QuestPatcher.Core.csproj
+++ b/QuestPatcher.Core/QuestPatcher.Core.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="QuestPatcher.QMod" Version="1.1.0" />
+    <PackageReference Include="QuestPatcher.QMod" Version="2.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/QuestPatcher.Core/QuestPatcherService.cs
+++ b/QuestPatcher.Core/QuestPatcherService.cs
@@ -48,9 +48,9 @@ namespace QuestPatcher.Core
             FilesDownloader = new ExternalFilesDownloader(SpecialFolders, Logger);
             DebugBridge = new AndroidDebugBridge(Logger, FilesDownloader, OnAdbDisconnect);
             PatchingManager = new PatchingManager(Logger, Config, DebugBridge, SpecialFolders, FilesDownloader, Prompter, new ApkSigner(), ExitApplication);
-            ModManager = new ModManager(Config, DebugBridge, Logger);
-            ModManager.RegisterModProvider(new QModProvider(ModManager, Config, Logger, DebugBridge, FilesDownloader));
             OtherFilesManager = new OtherFilesManager(Config, DebugBridge);
+            ModManager = new ModManager(Config, DebugBridge, Logger, OtherFilesManager);
+            ModManager.RegisterModProvider(new QModProvider(ModManager, Config, Logger, DebugBridge, FilesDownloader));
             InfoDumper = new InfoDumper(SpecialFolders, DebugBridge, ModManager, Logger, _configManager, PatchingManager);
 
             Logger.Debug($"QuestPatcherService constructed (QuestPatcher version {VersionUtil.QuestPatcherVersion})");

--- a/QuestPatcher/BrowseImportManager.cs
+++ b/QuestPatcher/BrowseImportManager.cs
@@ -609,7 +609,7 @@ namespace QuestPatcher
             Debug.Assert(_patchingManager.InstalledApp != null);
 
             // Prompt the user for outdated mods instead of enabling them automatically
-            if(mod.PackageVersion != _patchingManager.InstalledApp.Version&&!ignoreWrongVersion)
+            if(mod.PackageVersion != null && mod.PackageVersion != _patchingManager.InstalledApp.Version &&!ignoreWrongVersion)
             {
                 DialogBuilder builder = new()
                 {

--- a/QuestPatcher/Services/QuestPatcherUIService.cs
+++ b/QuestPatcher/Services/QuestPatcherUIService.cs
@@ -169,12 +169,12 @@ namespace QuestPatcher.Services
                         UseShellExecute = true
                     };
                     Process.Start(psi);
-                    ProcessStartInfo psi = new()
+                    ProcessStartInfo psi2 = new()
                     {
                         FileName = "https://bs.wgzeyu.com/buy/#bs_quest",
                         UseShellExecute = true
                     };
-                    Process.Start(psi);
+                    Process.Start(psi2);
                     DialogBuilder builder1 = new()
                     {
                         Title = "非原版BeatSaber！",

--- a/QuestPatcher/ViewModels/Modding/ModViewModel.cs
+++ b/QuestPatcher/ViewModels/Modding/ModViewModel.cs
@@ -115,7 +115,7 @@ namespace QuestPatcher.ViewModels.Modding
         {
             Debug.Assert(_patchingManager.InstalledApp != null);
             // Check game version, and prompt if it is incorrect to avoid users installing mods that may crash their game
-            if(Mod.PackageVersion != _patchingManager.InstalledApp.Version)
+            if(Mod.PackageVersion != null && Mod.PackageVersion != _patchingManager.InstalledApp.Version)
             {
                 DialogBuilder builder = new()
                 {


### PR DESCRIPTION
I see there was an attempt to sync up-stream code which included all the updates to the newer qmod schema, but then that merge commit got reverted.

I cherry-picked those commits which include the updates from up-stream.

https://github.com/Lauriethefish/QuestPatcher/commit/3ceb4ee5b41d60f62cf4ac3b3c6839099d73d558
and 
https://github.com/Lauriethefish/QuestPatcher/commit/d681a3ad338d7b3e33ca17eecba2d00410debf1c