### PR TITLE
Assume version ok when SemVer parse failed

### DIFF
--- a/QuestPatcher.Core/Patching/PatchingManager.cs
+++ b/QuestPatcher.Core/Patching/PatchingManager.cs
@@ -234,6 +234,11 @@ namespace QuestPatcher.Core.Patching
             {
                 throw;
             }
+            catch(ArgumentException)
+            {
+                Log.Logger.Warning("Failed to parse game version: {Version}", version);
+                Log.Logger.Warning("Assume version OK");
+            }
             catch(Exception e)
             {
                 Log.Logger.Error(e, "Failed to parse game version: {Version}", version);

--- a/QuestPatcher/BrowseImportManager.cs
+++ b/QuestPatcher/BrowseImportManager.cs
@@ -573,6 +573,7 @@ namespace QuestPatcher
                 
                 if (missingCoreMods.Count != 0)
                 {
+                    Log.Warning("Core Mods Missing: {Mods}", missingCoreMods.Aggregate("", (s, token) => $"{s}\n{token["id"]}-{token["version"]}"));
                     DialogBuilder builder = new()
                     {
                         Title = "缺失核心Mod",


### PR DESCRIPTION
因为要检测游戏版本是否>1.16.4，所以要识别并转换游戏版本字符串。
但是1.27.0的版本号是1.27.0_3631150051，并不符合版本号标准

逻辑更变为，如果版本号不符合标准，默认版本ok